### PR TITLE
Fix overly aggressive safety filters for baking content

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,7 +56,10 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("release")
+            // Only use release signing if keystore properties exist
+            if (keystorePropertiesFile.exists()) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             
             // Generate debug symbols for crash reporting
             isDebuggable = false

--- a/app/src/main/java/com/ravidor/forksure/CameraCapture.kt
+++ b/app/src/main/java/com/ravidor/forksure/CameraCapture.kt
@@ -103,11 +103,11 @@ fun CameraCapture(
                         }
                 )
                 Text(
-                    text = "Camera permission is required to take photos of your baked goods.",
+                    text = stringResource(R.string.camera_permission_required),
                     style = MaterialTheme.typography.bodyLarge
                 )
                 Text(
-                    text = "Please grant camera permission in your device settings if the permission dialog didn't appear.",
+                    text = stringResource(R.string.camera_permission_settings_hint),
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(top = 8.dp)
                 )
@@ -172,13 +172,14 @@ private fun CameraPreview(
 
         // Camera status indicator
         if (!isCameraReady) {
+            val initializingText = stringResource(R.string.camera_initializing)
             Text(
-                text = "Initializing camera...",
+                text = initializingText,
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .padding(16.dp)
                     .semantics {
-                        contentDescription = "Camera status: Initializing camera"
+                        contentDescription = "Camera status: $initializingText"
                     },
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface
@@ -225,13 +226,14 @@ private fun CameraPreview(
 
         // Capture status
         if (isCapturing) {
+            val capturingText = stringResource(R.string.camera_capturing)
             Text(
-                text = "Capturing photo...",
+                text = capturingText,
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .padding(16.dp)
                     .semantics {
-                        contentDescription = "Status: Capturing photo"
+                        contentDescription = "Status: $capturingText"
                     },
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface

--- a/app/src/main/java/com/ravidor/forksure/CameraCapture.kt
+++ b/app/src/main/java/com/ravidor/forksure/CameraCapture.kt
@@ -58,11 +58,10 @@ fun CameraCapture(
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val cameraPermissionState = rememberPermissionState(Manifest.permission.CAMERA)
-    var permissionRequested by remember { mutableStateOf(false) }
-
+    
+    // Request permission only once when camera screen loads, if not already granted
     LaunchedEffect(Unit) {
-        if (!cameraPermissionState.status.isGranted && !permissionRequested) {
-            permissionRequested = true
+        if (!cameraPermissionState.status.isGranted) {
             cameraPermissionState.launchPermissionRequest()
         }
     }
@@ -107,13 +106,11 @@ fun CameraCapture(
                     text = "Camera permission is required to take photos of your baked goods.",
                     style = MaterialTheme.typography.bodyLarge
                 )
-                if (permissionRequested) {
-                    Text(
-                        text = "Please grant camera permission in your device settings if the permission dialog didn't appear.",
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(top = 8.dp)
-                    )
-                }
+                Text(
+                    text = "Please grant camera permission in your device settings if the permission dialog didn't appear.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/ravidor/forksure/SecurityManager.kt
+++ b/app/src/main/java/com/ravidor/forksure/SecurityManager.kt
@@ -51,10 +51,9 @@ object SecurityManager {
     )
     
     private val dangerousInstructions = listOf(
-        Pattern.compile("(?i)\\b(poison|toxic|dangerous|harmful)\\b"),
-        Pattern.compile("(?i)\\b(raw|undercooked|unsafe|contaminated)\\b"),
-        Pattern.compile("(?i)\\b(allergy|allergen)\\s+(?!warning|information|note)"),
-        Pattern.compile("(?i)\\b(temperature|heat|burn|fire)\\s+(?!control|safety)")
+        Pattern.compile("(?i)\\b(poison|toxic|dangerous|harmful)\\s+(?!ingredients|free|warning)"),
+        Pattern.compile("(?i)\\b(unsafe|contaminated)\\s+(?!from|for|ingredients)"),
+        Pattern.compile("(?i)\\b(burn|fire)\\s+(?!proof|safe|resistant|place|oven|stove|until|slightly|golden)")
     )
 
     /**

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -80,6 +80,10 @@
     <string name="error_report_submission_failed">Bericht konnte nicht gesendet werden. Bitte versuchen Sie es erneut.</string>
     <string name="error_network_unavailable">Keine Internetverbindung. Bitte überprüfen Sie Ihr Netzwerk und versuchen Sie es erneut.</string>
     <string name="error_camera_permission_denied">Kameraberechtigung ist erforderlich, um Fotos zu machen</string>
+    <string name="camera_permission_required">Kameraberechtigung ist erforderlich, um Fotos Ihrer Backwaren zu machen.</string>
+    <string name="camera_permission_settings_hint">Bitte erteilen Sie die Kameraberechtigung in den Einstellungen Ihres Geräts, wenn das Berechtigungsdialog nicht erschienen ist.</string>
+    <string name="camera_initializing">Kamera wird initialisiert...</string>
+    <string name="camera_capturing">Foto wird aufgenommen...</string>
     <string name="error_image_too_large">Bild ist zu groß. Bitte versuchen Sie es mit einem kleineren Bild.</string>
     <string name="error_invalid_image_format">Ungültiges Bildformat. Bitte versuchen Sie es mit einem anderen Bild.</string>
     <string name="error_server_unavailable">Service vorübergehend nicht verfügbar. Bitte versuchen Sie es später erneut.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -80,6 +80,10 @@
     <string name="error_report_submission_failed">Error al enviar el reporte. Por favor, inténtalo de nuevo.</string>
     <string name="error_network_unavailable">Sin conexión a internet. Por favor verifica tu red e inténtalo de nuevo.</string>
     <string name="error_camera_permission_denied">Se requiere permiso de cámara para tomar fotos</string>
+    <string name="camera_permission_required">Se requiere permiso de cámara para tomar fotos de tus productos horneados.</string>
+    <string name="camera_permission_settings_hint">Por favor concede permiso de cámara en la configuración de tu dispositivo si no apareció el diálogo de permisos.</string>
+    <string name="camera_initializing">Inicializando cámara...</string>
+    <string name="camera_capturing">Capturando foto...</string>
     <string name="error_image_too_large">La imagen es muy grande. Por favor intenta con una imagen más pequeña.</string>
     <string name="error_invalid_image_format">Formato de imagen inválido. Por favor intenta con una imagen diferente.</string>
     <string name="error_server_unavailable">Servicio temporalmente no disponible. Por favor inténtalo más tarde.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -80,6 +80,10 @@
     <string name="error_report_submission_failed">Échec de l\'envoi du signalement. Veuillez réessayer.</string>
     <string name="error_network_unavailable">Pas de connexion internet. Veuillez vérifier votre réseau et réessayer.</string>
     <string name="error_camera_permission_denied">La permission de caméra est requise pour prendre des photos</string>
+    <string name="camera_permission_required">La permission de caméra est requise pour prendre des photos de vos produits de boulangerie.</string>
+    <string name="camera_permission_settings_hint">Veuillez accorder la permission de caméra dans les paramètres de votre appareil si la boîte de dialogue de permission n\'est pas apparue.</string>
+    <string name="camera_initializing">Initialisation de la caméra...</string>
+    <string name="camera_capturing">Capture de photo...</string>
     <string name="error_image_too_large">L\'image est trop grande. Veuillez essayer avec une image plus petite.</string>
     <string name="error_invalid_image_format">Format d\'image invalide. Veuillez essayer avec une image différente.</string>
     <string name="error_server_unavailable">Service temporairement indisponible. Veuillez réessayer plus tard.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,10 @@
     <string name="error_report_submission_failed">Failed to submit report. Please try again.</string>
     <string name="error_network_unavailable">No internet connection. Please check your network and try again.</string>
     <string name="error_camera_permission_denied">Camera permission is required to take photos</string>
+    <string name="camera_permission_required">Camera permission is required to take photos of your baked goods.</string>
+    <string name="camera_permission_settings_hint">Please grant camera permission in your device settings if the permission dialog didn\'t appear.</string>
+    <string name="camera_initializing">Initializing camera...</string>
+    <string name="camera_capturing">Capturing photo...</string>
     <string name="error_image_too_large">Image is too large. Please try a smaller image.</string>
     <string name="error_invalid_image_format">Invalid image format. Please try a different image.</string>
     <string name="error_server_unavailable">Service temporarily unavailable. Please try again later.</string>


### PR DESCRIPTION
Allow legitimate cooking terms like temperature, heat, raw ingredients - Make safety patterns more specific and cooking-friendly - Maintain security while enabling proper baking analysis

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/ForkSure/5)
<!-- Reviewable:end -->
