### PR TITLE
chore: add PR workflow helpers (pre-push guard + new_pr script)

### DIFF
--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installs a pre-push git hook that prevents direct pushes to the main branch.
+# This is a local safety net; your repo already has server-side protections,
+# but this avoids accidental pushes from this machine.
+#
+# Usage:
+#   bash scripts/install_hooks.sh
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "${REPO_ROOT}" ]]; then
+  echo "Not inside a git repository." >&2
+  exit 1
+fi
+
+HOOK_DIR="${REPO_ROOT}/.git/hooks"
+HOOK_PATH="${HOOK_DIR}/pre-push"
+
+mkdir -p "${HOOK_DIR}"
+
+cat >"${HOOK_PATH}" <<'HOOK'
+#!/usr/bin/env bash
+# pre-push: block direct pushes to main
+set -euo pipefail
+
+# Read refs from stdin: local_ref local_sha remote_ref remote_sha
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # Normalize ref names if needed
+  if [[ "${local_ref}" == "refs/heads/main" ]] || [[ "${remote_ref}" == "refs/heads/main" ]]; then
+    echo "[pre-push] Direct pushes to main are blocked. Please open a PR." >&2
+    echo "[pre-push] Tip: create a branch and push it, then run: gh pr create --fill --base main" >&2
+    exit 1
+  fi
+done
+
+exit 0
+HOOK
+
+chmod +x "${HOOK_PATH}"
+
+echo "Installed pre-push hook at ${HOOK_PATH}"

--- a/scripts/new_pr.sh
+++ b/scripts/new_pr.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# new_pr.sh: Push current branch and open a GitHub Pull Request.
+# - If on main, it will create a new branch from main first.
+# - Uses gh CLI to create a PR; requires 'gh auth status' to be logged in.
+#
+# Usage:
+#   bash scripts/new_pr.sh "Title of the PR" [--fill]
+#   bash scripts/new_pr.sh --fill            # use last commit message as title/body
+#
+# Options:
+#   --base <branch>    Base branch (default: main)
+#   --fill             Use commit message(s) for PR title/body
+#   --body <text>      PR body text
+#
+BASE="main"
+FILL=0
+TITLE=""
+BODY=""
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      BASE="$2"; shift 2;;
+    --fill)
+      FILL=1; shift;;
+    --body)
+      BODY="$2"; shift 2;;
+    *)
+      if [[ -z "$TITLE" ]]; then
+        TITLE="$1"; shift
+      else
+        echo "Unknown arg: $1" >&2; exit 2
+      fi
+      ;;
+  esac
+done
+
+# Ensure gh
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI (gh) not found. Install from https://cli.github.com/" >&2
+  exit 2
+fi
+
+# Ensure repo state
+git rev-parse --is-inside-work-tree >/dev/null
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" == "HEAD" ]]; then
+  echo "You are in a detached HEAD state. Please checkout a branch." >&2
+  exit 2
+fi
+
+# If on main, create a new branch
+if [[ "$CURRENT_BRANCH" == "$BASE" ]]; then
+  SAFE_NAME=$(date +"feat/%Y%m%d-%H%M%S")
+  echo "On $BASE; creating new branch: $SAFE_NAME"
+  git fetch origin "$BASE"
+  git checkout -b "$SAFE_NAME" "origin/$BASE"
+  CURRENT_BRANCH="$SAFE_NAME"
+fi
+
+# Push current branch
+git push -u origin "$CURRENT_BRANCH"
+
+echo "Opening PR: head=$CURRENT_BRANCH base=$BASE"
+if [[ $FILL -eq 1 ]]; then
+  gh pr create --base "$BASE" --head "$CURRENT_BRANCH" --fill
+else
+  if [[ -z "$TITLE" ]]; then
+    TITLE=$(git log -1 --pretty=%s)
+  fi
+  if [[ -z "$BODY" ]]; then
+    BODY="Automated PR for branch $CURRENT_BRANCH"
+  fi
+  gh pr create --base "$BASE" --head "$CURRENT_BRANCH" --title "$TITLE" --body "$BODY"
+fi


### PR DESCRIPTION
This PR adds local helpers to adopt a branch-and-PR workflow:

- scripts/install_hooks.sh\n  Installs a local pre-push hook that blocks direct pushes to 'main' from this machine.
- scripts/new_pr.sh\n  Pushes the current branch and opens a GitHub PR non-interactively (supports --fill or custom title/body).
- Run:
- bash scripts/install_hooks.sh\n- bash scripts/new_pr.sh --fill   # from a topic branch
- These are local conveniences; server-side branch protections remain the source of truth.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/ForkSure/30)
<!-- Reviewable:end -->
